### PR TITLE
Refactor dependencies file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 gem 'awesome_print'
 gem 'colorize'
-gem 'dotenv'
 gem 'faraday'
 gem 'json'
 gem 'nokogiri'

--- a/postwoman
+++ b/postwoman
@@ -14,6 +14,6 @@ end
 while (line = Readline.readline('> ', true))
   handle_history(line)
 
-  load_loaders
+  DynamicDependencies.load_loaders
   attempt_command(line)
 end

--- a/spec/commands/debug_spec.rb
+++ b/spec/commands/debug_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Debug command' do
   it 'calls binding.pry if debugger is binding.pry' do
-    ENV['DEBUGGER'] = 'pry'
+    allow(Env.config).to receive(:[]).with(:debugger).and_return('pry')
     command_obj = Commands::Debug.new(ArgsHandler.parse('debug'))
     command_binding = double('binding', pry: nil)
     allow(command_obj).to receive(:binding) { command_binding }
@@ -13,7 +13,7 @@ describe 'Debug command' do
   end
 
   it 'calls byebug if debugger is byebug' do
-    ENV['DEBUGGER'] = 'byebug'
+    allow(Env.config).to receive(:[]).with(:debugger).and_return('byebug')
     allow(Byebug).to receive(:attach)
 
     attempt_command('debug')
@@ -22,7 +22,7 @@ describe 'Debug command' do
   end
 
   it 'calls debug if debugger is debug' do
-    ENV['DEBUGGER'] = 'debug'
+    allow(Env.config).to receive(:[]).with(:debugger).and_return('debug')
     command_obj = Commands::Debug.new(ArgsHandler.parse('debug'))
     command_binding = double('binding', break: nil)
     allow(command_obj).to receive(:binding) { command_binding }

--- a/spec/commands/new_spec.rb
+++ b/spec/commands/new_spec.rb
@@ -25,7 +25,7 @@ describe 'New command' do
         end
       end
     TEXT
-    ENV['EDITOR'] = 'emacs'
+    allow(Env.config).to receive(:[]).with(:editor).and_return('emacs')
     command = Commands::New.new(ArgsHandler.parse('new testing'))
     pretend_file_doesnt_exist('loaders/testing.rb')
 
@@ -41,7 +41,7 @@ describe 'New command' do
   end
 
   it 'edits existing loader on default editor when loader already exists', :file_mocking do
-    ENV['EDITOR'] = 'emacs'
+    allow(Env.config).to receive(:[]).with(:editor).and_return('emacs')
     command = Commands::New.new(ArgsHandler.parse('new testing'))
     pretend_file_exists('loaders/testing.rb')
 
@@ -66,7 +66,7 @@ describe 'New command' do
   end
 
   it 'treats loader name to be downcased', :file_mocking do
-    ENV['EDITOR'] = 'emacs'
+    allow(Env.config).to receive(:[]).with(:editor).and_return('emacs')
     command = Commands::New.new(ArgsHandler.parse('new Testing2'))
     pretend_file_exists('loaders/testing2.rb')
 
@@ -102,7 +102,7 @@ describe 'New command' do
 
   context 'when default editor is not set' do
     it 'outputs message after loader creation' do
-      ENV['EDITOR'] = nil
+      allow(Env.config).to receive(:[]).with(:editor).and_return(nil)
       command = Commands::New.new(ArgsHandler.parse('new testing'))
       pretend_file_doesnt_exist('loaders/testing.rb')
 
@@ -112,13 +112,13 @@ describe 'New command' do
           ┌────────────────────────┐
           │ Creating new loader... │
           └────────────────────────┘
-          The environment variable 'EDITOR' has not been set to open the target file
+          The setting 'editor' has not been set to open the target file
         TEXT
       )
     end
 
     it 'outputs message after trying to edit loader' do
-      ENV['EDITOR'] = nil
+      allow(Env.config).to receive(:[]).with(:editor).and_return(nil)
       command = Commands::New.new(ArgsHandler.parse('new testing'))
       pretend_file_exists('loaders/testing.rb')
 
@@ -128,7 +128,7 @@ describe 'New command' do
           ┌───────────────────┐
           │ Editing loader... │
           └───────────────────┘
-          The environment variable 'EDITOR' has not been set to open the target file
+          The setting 'editor' has not been set to open the target file
         TEXT
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require_relative File.dirname(__FILE__) + '/../utils/dependencies.rb'
 StartUp.execute
+DynamicDependencies.load_loaders
 
 I18n.locale = :en
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 require_relative File.dirname(__FILE__) + '/../utils/dependencies.rb'
+StartUp.execute
+
+I18n.locale = :en
+
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 
 RSpec.configure do |config|
@@ -17,9 +21,6 @@ RSpec.configure do |config|
     Env.workbench.clear
 
     allow(Readline).to receive(:get_screen_size) { [Float::INFINITY, Float::INFINITY] }
-
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with('config.yml').and_return(false)
   end
 
   config.mock_framework = :rspec

--- a/spec/style/apply_spec.rb
+++ b/spec/style/apply_spec.rb
@@ -3,10 +3,47 @@ require 'spec_helper'
 describe Style do
   context :apply do
     it 'works successfully for wrapping tags' do
+      allow(Env).to receive(:config).and_return(
+        {
+          theme: {
+            tags: {
+              h1: ["\e[38;2;227;64;107m\e[1m", "\e[m"]
+            }
+          }
+        }
+      )
       expect(Style.apply('<h1>some text I have</h1>')).to eq("\e[38;2;227;64;107m\e[1msome text I have\e[m")
     end
 
     it 'works successfully for boxes' do
+      allow(Env).to receive(:config).and_return(
+        {
+          theme: {
+            tags: {
+              h1: ["\e[38;2;227;64;107m\e[1m", "\e[m"]
+            },
+            tables: {
+              space_linebroken: true,
+              padding: 1,
+              corners: {
+                top_right: '┌',
+                top_left: '┐',
+                bottom_right: '└',
+                bottom_left: '┘'
+              },
+              straight: {
+                vertical: '│',
+                horizontal: '─'
+              },
+              junctions: {
+                top: '┬',
+                middle: '┼',
+                bottom: '┴'
+              }
+            }
+          },
+        }
+      )
       expect(Style.apply('<box><h1>some text I have<h1></box>')).to eq(
         <<~TEXT
           ┌──────────────────┐

--- a/spec/style/apply_spec.rb
+++ b/spec/style/apply_spec.rb
@@ -41,7 +41,7 @@ describe Style do
                 bottom: '┴'
               }
             }
-          },
+          }
         }
       )
       expect(Style.apply('<box><h1>some text I have<h1></box>')).to eq(

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -1,2 +1,0 @@
-EDITOR=vi
-DEBUGGER=pry

--- a/utils/commands/base.rb
+++ b/utils/commands/base.rb
@@ -37,11 +37,11 @@ module Commands
     end
 
     def edit_loader(name)
-      system("#{ENV['EDITOR']} loaders/#{name}.rb")
+      system("#{Env.config[:editor]} loaders/#{name}.rb")
     end
 
     def edit_helper(name)
-      system("#{ENV['EDITOR']} loaders/utils/#{name}.rb")
+      system("#{Env.config[:editor]} loaders/utils/#{name}.rb")
     end
 
     def new_or_edit(file_name, path, default_content, label)
@@ -49,9 +49,9 @@ module Commands
 
       if File.exist?(path)
         puts Views::Commands::Base.editing(label)
-        return puts Views::Commands::Base.editor_not_found_error if ENV['EDITOR'].nil?
+        return puts Views::Commands::Base.editor_not_found_error if Env.config[:editor].nil?
 
-        return system("#{ENV['EDITOR']} #{path}")
+        return system("#{Env.config[:editor]} #{path}")
       end
 
       puts Views::Commands::Base.creating(label)
@@ -59,9 +59,9 @@ module Commands
         f.write(default_content)
       end
 
-      return puts Views::Commands::Base.editor_not_found_warning if ENV['EDITOR'].nil?
+      return puts Views::Commands::Base.editor_not_found_warning if Env.config[:editor].nil?
 
-      system("#{ENV['EDITOR']} #{path}")
+      system("#{Env.config[:editor]} #{path}")
     end
 
     def obrigatory_positional_arg(index, custom_name = nil)
@@ -74,7 +74,7 @@ module Commands
     end
 
     def start_debug
-      case ENV['DEBUGGER']
+      case Env.config[:debugger]
       when 'pry'
         binding.pry
       when 'byebug'

--- a/utils/default_config.yml
+++ b/utils/default_config.yml
@@ -1,4 +1,6 @@
 :language: en
+:editor: code
+:debugger: pry
 :theme:
   :tags:
     :h1:

--- a/utils/dependencies.rb
+++ b/utils/dependencies.rb
@@ -18,38 +18,8 @@ require 'bundler/setup'
 Bundler.require
 require_relative '../utils/loaders/builtin/base'
 
-Faraday.default_adapter = :typhoeus
-
-def needed_file(path, template_path)
-  return if File.exist?(path)
-
-  File.open(path, 'w') do |f|
-    f.write(File.read(template_path))
-  end
-end
-
-def load_loaders
-  return unless load_loader('loaders/base.rb')
-
-  Dir[File.dirname(__FILE__) + '/../loaders/**/*.rb'].each do |file|
-    load_loader(file)
-  end
-end
-
-def load_loader(loader_path)
-  load loader_path
-rescue Exception => e
-  puts "Loader '#{loader_path.split('/').last[..-4]}' has syntax errors and couldn't be loaded:".red
-  puts e.full_message
-end
-
-needed_file('loaders/base.rb', 'templates/loader_base.rb')
-needed_file('.env', 'templates/.env.example')
-
 Dir[File.dirname(__FILE__) + '/../utils/**/base.rb'].each { |file| require_relative file }
 Dir[File.dirname(__FILE__) + '/../utils/**/*.rb'].each { |file| require_relative file }
-load_loaders
-
-Dotenv.overload('templates/.env.example', '.env')
+DynamicDependencies.load_loaders
 
 I18n.load_path += Dir[File.dirname(__FILE__) + '/../utils/locales/**/*.yml']

--- a/utils/dynamic_dependencies.rb
+++ b/utils/dynamic_dependencies.rb
@@ -1,0 +1,18 @@
+module DynamicDependencies
+  module_function
+
+  def load_loaders
+    return unless load_loader('loaders/base.rb')
+
+    Dir[File.dirname(__FILE__) + '/../loaders/**/*.rb'].each do |file|
+      load_loader(file)
+    end
+  end
+
+  def load_loader(loader_path)
+    load loader_path
+  rescue Exception => e
+    puts "Loader '#{loader_path.split('/').last[..-4]}' has syntax errors and couldn't be loaded:".red
+    puts e.full_message
+  end
+end

--- a/utils/dynamic_dependencies.rb
+++ b/utils/dynamic_dependencies.rb
@@ -4,14 +4,14 @@ module DynamicDependencies
   def load_loaders
     return unless load_loader('loaders/base.rb')
 
-    Dir[File.dirname(__FILE__) + '/../loaders/**/*.rb'].each do |file|
+    Dir["#{File.dirname(__FILE__)}/../loaders/**/*.rb"].each do |file|
       load_loader(file)
     end
   end
 
   def load_loader(loader_path)
     load loader_path
-  rescue Exception => e
+  rescue Exception => e # rubocop:disable Lint/RescueException
     puts "Loader '#{loader_path.split('/').last[..-4]}' has syntax errors and couldn't be loaded:".red
     puts e.full_message
   end

--- a/utils/loaders/builtin/base.rb
+++ b/utils/loaders/builtin/base.rb
@@ -18,7 +18,7 @@ module Loaders
           http_method: http_method,
           url: checked_url,
           params: params_with_env,
-          headers:
+          headers: headers
         }
       end
 

--- a/utils/locales/en/commands/base.yml
+++ b/utils/locales/en/commands/base.yml
@@ -2,7 +2,7 @@ en:
   commands:
     base:
       missing_positional_argument: "Missing #%{index} positional argument: '%{name}'"
-      editor_not_found: "The environment variable 'EDITOR' has not been set to open the target file"
+      editor_not_found: "The setting 'editor' has not been set to open the target file"
       editing: "Editing %{name}..."
       creating: "Creating new %{name}..."
       invalid_subcommand: "Invalid subcommand: '%{name}'"

--- a/utils/locales/pt-BR/commands/base.yml
+++ b/utils/locales/pt-BR/commands/base.yml
@@ -2,7 +2,7 @@ pt-BR:
   commands:
     base:
       missing_positional_argument: "Faltando o argumento posicional #%{index}: '%{name}'"
-      editor_not_found: "A variável de ambiente 'EDITOR' não foi definida para abrir o arquivo de destino."
+      editor_not_found: "A configuração 'editor' não foi definida para abrir o arquivo de destino."
       editing: "Editando %{name}..."
       creating: "Criando novo(a) %{name}..."
       invalid_subcommand: "Subcomando inválido: '%{name}'"

--- a/utils/start_up.rb
+++ b/utils/start_up.rb
@@ -2,6 +2,10 @@ module StartUp
   module_function
 
   def execute
+    needed_file('loaders/base.rb', 'templates/loader_base.rb')
+
+    Faraday.default_adapter = :typhoeus
+
     Readline.completion_append_character = ' '
     Readline.completion_proc = Autocompletion.generate_proc
 
@@ -11,5 +15,13 @@ module StartUp
     I18n.locale = Env.config[:language]
 
     puts Views.start_up_message
+  end
+
+  def needed_file(path, template_path)
+    return if File.exist?(path)
+
+    File.open(path, 'w') do |f|
+      f.write(File.read(template_path))
+    end
   end
 end


### PR DESCRIPTION
### Changes
- Takes code that did not belong to `dependencies.rb` and place it on `dynamic_dependencies.rb` and `start_up.rb` files
- Removes `.env` completely in favor of `config.yml`
- Fixes tests accordingly.